### PR TITLE
Root finding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.31.6)
 
-set(PACKAGE_VERSION 1.0.4)
+set(PACKAGE_VERSION 1.0.5)
 
 project(BasisSplines VERSION ${PACKAGE_VERSION})
 

--- a/bindings/python/basisSplines/basisSplines.cpp
+++ b/bindings/python/basisSplines/basisSplines.cpp
@@ -5,6 +5,7 @@
 
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 
@@ -385,6 +386,29 @@ Returns:
 
 Returns:
      Spline: Clamped spline.
+)doc")
+      .def("getRoots",
+           py::overload_cast<int, double>(&Spline::getRoots, py::const_),
+           "maxIter"_a = 10, "accAbs"_a = 1e-6,
+           R"doc(Get the roots along all output dimensions.
+
+Args:
+     maxIter (int, optional): Maximum number of iterations. Default is 10.
+     accAbs (float, optional): Tolerance for the spline output to be considered zero. Default is 1e-6.
+Returns:
+     List[np.ndarray]: Roots along all output dimensions.
+)doc")
+      .def("getRoots",
+           py::overload_cast<int, int, double>(&Spline::getRoots, py::const_),
+           "dim"_a, "maxIter"_a = 10, "accAbs"_a = 1e-6,
+           R"doc(Get the roots along the specified output dimension.
+
+Args:
+     dim (int): Output dimension to evaluate.
+     maxIter (int, optional): Maximum number of iterations. Default is 10.
+     accAbs (float, optional): Tolerance for the spline output to be considered zero. Default is 1e-6.
+Returns:
+     np.ndarray: Roots along the given output dimension.
 )doc")
       .def("__neg__", &Spline::operator-,
            R"doc(Create new spline with negated spline coefficients.

--- a/examples/cpp/include/helper.h
+++ b/examples/cpp/include/helper.h
@@ -51,6 +51,26 @@ void plotSpline(const Bs::Spline &spline, const Eigen::ArrayXd &points,
       .display_name("breakpoints");
 }
 
+/**
+ * @brief Plot the given "roots" of a "spline".
+ *
+ * @param spline Spline function to corresponding to the "roots".
+ * @param roots Roots of the "spline".
+ * @param axesHandle Axis handle for plotting.
+ * @param dim output dimension to plot.
+ */
+void plotRoots(const Bs::Spline &spline, const Eigen::ArrayXd &roots,
+               const Mt::axes_handle axesHandle, int dim = 0) {
+  const Eigen::ArrayXd splineValues{spline(roots)(Eigen::all, dim)};
+
+  axesHandle
+      ->scatter(std::vector<double>{roots.begin(), roots.end()},
+                std::vector<double>{splineValues.begin(), splineValues.end()})
+      ->marker_style(matplot::line_spec::marker_style::cross)
+      .marker_size(10.0)
+      .display_name("roots");
+}
+
 void plotSpline2d(const Bs::Spline &spline, const Eigen::ArrayXd &points,
                   const Mt::axes_handle axesHandle,
                   const std::array<int, 2> &dims) {

--- a/examples/cpp/include/helper.h
+++ b/examples/cpp/include/helper.h
@@ -54,7 +54,7 @@ void plotSpline(const Bs::Spline &spline, const Eigen::ArrayXd &points,
 /**
  * @brief Plot the given "roots" of a "spline".
  *
- * @param spline Spline function to corresponding to the "roots".
+ * @param spline Spline function corresponding to the "roots".
  * @param roots Roots of the "spline".
  * @param axesHandle Axis handle for plotting.
  * @param dim output dimension to plot.

--- a/examples/cpp/splineRoots.cpp
+++ b/examples/cpp/splineRoots.cpp
@@ -1,0 +1,52 @@
+#include <Eigen/Core>
+#include <matplot/matplot.h>
+#include <string>
+
+#include "basisSplines/basis.h"
+#include "basisSplines/spline.h"
+#include "helper.h"
+
+namespace Bs = BasisSplines;
+namespace Mt = matplot;
+
+int main(int argc, char *argv[]) {
+  // basis of order 3 with 4 breakpoints
+  std::shared_ptr<Bs::Basis> basis{std::make_shared<Bs::Basis>(
+      Eigen::ArrayXd{{0.0, 0.0, 0.0, 0.0, 0.4, 0.7, 1.0, 1.0, 1.0, 1.0}}, 4)};
+
+  // spline of order 3
+  const Eigen::MatrixXd coeffs{{1.0, -1.0, 0.6, -0.7, 0.0, 0.0},
+                               {0.0, 0.0, 0.0, -0.7, 1.0, -1.0}};
+  Bs::Spline spline{basis, coeffs.transpose()};
+
+  // setup figure
+  auto figureHandle{Mt::figure()};
+  figureHandle->size(800, 800);
+
+  // plot roots
+  const auto roots{spline.getRoots()};
+
+  Eigen::Index nAxes{spline.dim()};
+
+  for (int dim{}; dim < spline.dim(); ++dim) {
+    auto axesHandle = Mt::subplot(figureHandle, nAxes, 1, dim);
+
+    axesHandle->hold(true);
+    axesHandle->grid(true);
+    axesHandle->ylim({-1.0, 1.0});
+    axesHandle->xlabel("x/1");
+    axesHandle->ylabel(std::format("s_{}(x)/1", dim));
+
+    plotSpline(spline, Eigen::ArrayXd::LinSpaced(121, -0.1, 1.1), axesHandle,
+               dim);
+    plotRoots(spline, roots[dim], axesHandle, dim);
+
+    Mt::legend(Mt::on)->location(Mt::legend::general_alignment::bottomleft);
+  }
+
+  // save and show figure
+  saveFigure(figureHandle, getFileName(argc, argv), getFileEnding(argc, argv));
+  Mt::show();
+
+  return 0;
+}

--- a/examples/python/helper/helper.py
+++ b/examples/python/helper/helper.py
@@ -27,6 +27,19 @@ def plotSpline(
     axesHandle.plot(breakpoints, splineValsBps, "D", label="breakpoints")
 
 
+def plotRoots(
+    spline: bs.Spline, roots: np.ndarray, axesHandle: plt.Axes, dim: int = 0
+):
+    """Plot the roots of a spline function."""
+    if len(roots) == 0:
+        return
+
+    splineValues = spline(roots)[:, dim]
+    axesHandle.plot(
+        roots, splineValues, "x", markersize=10, label="roots", markeredgewidth=2
+    )
+
+
 def plotSpline2d(
     spline: bs.Spline, points: np.ndarray, axesHandle: plt.Axes, dims: Tuple[int, int]
 ):

--- a/examples/python/splineRoots.py
+++ b/examples/python/splineRoots.py
@@ -1,0 +1,40 @@
+import basisSplines as bs
+import matplotlib.pyplot as plt
+import numpy as np
+from helper import helper
+
+
+def main():
+    # basis of order 3 with 4 breakpoints
+    basis = bs.Basis(np.array([0.0, 0.0, 0.0, 0.0, 0.4, 0.7, 1.0, 1.0, 1.0, 1.0]), 4)
+
+    # spline of order 3 with 2 dimensions
+    coeffs = np.array([[1.0, 0.0], [-1.0, 0.0], [0.6, 0.0], [-0.7, -0.7], [0.0, 1.0], [0.0, -1.0]])
+    spline = bs.Spline(basis, coeffs)
+
+    # plot roots
+    roots = spline.getRoots()
+
+    nAxes = spline.dim()
+
+    # setup figure
+    _, axs = plt.subplots(nAxes, 1, figsize=(8, 8))
+    points = np.linspace(-0.1, 1.1, 121)
+
+    for dim in range(spline.dim()):
+        axs[dim].grid(True)
+        axs[dim].set_ylim([-1.0, 1.0])
+        axs[dim].set_xlabel("x/1")
+        axs[dim].set_ylabel(f"s_{dim}(x)/1")
+
+        helper.plotSpline(spline, points, axs[dim], dim)
+        helper.plotRoots(spline, roots[dim], axs[dim], dim)
+
+        axs[dim].legend(loc="lower left")
+
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/include/basisSplines/spline.h
+++ b/include/basisSplines/spline.h
@@ -428,7 +428,6 @@ private:
    * [1] K. Mørken and M. Reimers, “An unconditionally convergent method for
    computing zeros of splines and polynomials,” Math. Comp., vol. 76, no. 258,
    pp. 845–865, Jan. 2007, doi: 10.1090/S0025-5718-07-01923-0.
-
    *
    * @param rootIdx Index corresponding to a pair of coefficients containing a
    root.
@@ -442,7 +441,7 @@ private:
     Eigen::VectorXd coeffs{inserted.getCoefficients()(Eigen::all, dim)};
     double rootGuess{inserted.basis()->greville(rootIdx)};
 
-    for (int iter = 0; iter < maxIter && ~isRoot(rootGuess, dim, accAbs);
+    for (int iter = 0; iter < maxIter && !isRoot(rootGuess, dim, accAbs);
          iter++) {
       double leftCoeff{coeffs(rootIdx)};
       double leftGrev{inserted.basis()->greville(rootIdx)};
@@ -523,7 +522,7 @@ private:
   }
 
   /**
-   * @brief Determines if a "value" is condsidered a root for the given absolte
+   * @brief Determines if a "value" is considered a root for the given absolute
    * tolerance "absTol".
    *
    * @param value Test value to check for root.

--- a/include/basisSplines/spline.h
+++ b/include/basisSplines/spline.h
@@ -251,6 +251,58 @@ public:
   }
 
   /**
+   * @brief Get the roots along all output dimensions.
+   *
+   * The roots are estimated with algorithm from [1] until the maximum number of
+   iterations or the desired accuracy.
+   *
+   * [1] K. Mørken and M. Reimers, “An unconditionally convergent method for
+   computing zeros of splines and polynomials,” Math. Comp., vol. 76, no. 258,
+   pp. 845–865, Jan. 2007, doi: 10.1090/S0025-5718-07-01923-0.
+   *
+   * @param maxIter Maximum number of iterations.
+   * @param accAbs Tolerance for the spline output to be considered zero.
+   * @return Eigen::ArrayXd Roots along all output dimensions.
+   */
+  std::vector<Eigen::ArrayXd> getRoots(int maxIter = 10,
+                                       double accAbs = 1e-6) const {
+    std::vector<Eigen::ArrayXd> zeros(m_coefficients.cols());
+
+    for (int dim{}; dim < m_coefficients.cols(); ++dim)
+      zeros[dim] = getRoots(dim, maxIter, accAbs);
+
+    return zeros;
+  }
+
+  /**
+   * @brief Get the roots along the specified output dimension.
+   *
+   * The roots are estimated with algorithm from [1] until the maximum number of
+   iterations or the desired accuracy.
+   *
+   * [1] K. Mørken and M. Reimers, “An unconditionally convergent method for
+   computing zeros of splines and polynomials,” Math. Comp., vol. 76, no. 258,
+   pp. 845–865, Jan. 2007, doi: 10.1090/S0025-5718-07-01923-0.
+   *
+   * @param dim Output dimension to evaluate.
+   * @param maxIter Maximum number of iterations.
+   * @param accAbs Tolerance for the spline output to be considered zero.
+   * @return Eigen::ArrayXd Roots along the given output dimension.
+   */
+  Eigen::ArrayXd getRoots(int dim, int maxIter = 10,
+                          double accAbs = 1e-6) const {
+    auto [rootIdcs, roots] = getRootIdcs(dim, accAbs);
+
+    int cntRoot{};
+    for (int rootIdx : rootIdcs) {
+      if (rootIdx >= 0)
+        roots(cntRoot++) = estimateRoot(rootIdx, dim, maxIter, accAbs);
+    }
+
+    return roots;
+  }
+
+  /**
    * @brief Determine a spline representing the "first" and the "last" segment
    * of "this" spline.
    *
@@ -361,6 +413,127 @@ private:
       coeffsNew(knotIdx) = coeffs(knotIdx - 1);
 
     return coeffsNew;
+  }
+
+  /**
+   * @brief Iterative algorithm from [1] to estimate the root between two
+   sign-changing coefficients corresponding to "rootIdx".
+   *
+   * In each iteration, a knot is inserted at the current root candidate. The
+   current root candidate is determined as the center between the current left
+   and right greville sites.
+   * The algorithm terminates after a maximum number of iterations or if a root
+   is found with the desired accuracy.
+   *
+   * [1] K. Mørken and M. Reimers, “An unconditionally convergent method for
+   computing zeros of splines and polynomials,” Math. Comp., vol. 76, no. 258,
+   pp. 845–865, Jan. 2007, doi: 10.1090/S0025-5718-07-01923-0.
+
+   *
+   * @param rootIdx Index corresponding to a pair of coefficients containing a
+   root.
+   * @param dim Output dimension to evaluate.
+   * @param maxIter Maximum number of iterations.
+   * @param accAbs Tolerance for the spline output to be considered zero.
+   * @return double Root estimates along the given output dimension.
+   */
+  double estimateRoot(int rootIdx, int dim, int maxIter, double accAbs) const {
+    Spline inserted{*this};
+    Eigen::VectorXd coeffs{inserted.getCoefficients()(Eigen::all, dim)};
+    double rootGuess{inserted.basis()->greville(rootIdx)};
+
+    for (int iter = 0; iter < maxIter && ~isRoot(rootGuess, dim, accAbs);
+         iter++) {
+      double leftCoeff{coeffs(rootIdx)};
+      double leftGrev{inserted.basis()->greville(rootIdx)};
+      bool leftAlmostZero{abs(leftCoeff) <= accAbs};
+
+      // left greville is root
+      if (leftAlmostZero)
+        rootGuess = leftGrev;
+
+      // guess root between left and right greville
+      else {
+        double rightCoeff{coeffs(rootIdx + 1)};
+        double rightGrev{inserted.basis()->greville(rootIdx + 1)};
+        bool rightAlmostZero{abs(rightCoeff) <= accAbs};
+
+        double param{-leftCoeff / (rightCoeff - leftCoeff)};
+        rootGuess = (1 - param) * leftGrev + param * rightGrev;
+
+        inserted = inserted.insertKnots(Eigen::ArrayXd{{rootGuess}});
+        coeffs = inserted.getCoefficients()(Eigen::all, dim);
+
+        // after insertion, check if zero moved between new greville and former
+        // right greville
+        if (coeffs(rootIdx + 1) * coeffs(rootIdx + 2) <= 0)
+          rootIdx += 1;
+      }
+    }
+
+    return rootGuess;
+  };
+
+  /**
+   * @brief Get indices of coefficient pairs that contain a root and get trivial
+   * roots.
+   *
+   * Each negative index corresponds to a trivial root and must not be
+   * processed further. Positive indices correspond to a non-trivial root. The
+   * root must be estimated.
+   *
+   * @param dim Dimension of coefficients to evaluate.
+   * @param absTol Absolute tolerance defining coefficients close to zero.
+   * @return std::pair<Eigen::ArrayXi, Eigen::ArrayXd> Indices of coefficient
+   * pairs containing a root and trivial roots.
+   */
+  std::pair<Eigen::ArrayXi, Eigen::ArrayXd> getRootIdcs(int dim,
+                                                        double absTol) const {
+    const Eigen::VectorXd coeffs{m_coefficients(Eigen::all, dim)};
+    const int maxRoots = coeffs.size();
+
+    Eigen::ArrayXi rootIdcs = Eigen::ArrayXi::Constant(maxRoots, -1);
+    Eigen::ArrayXd roots(maxRoots);
+    int cntRoots{};
+
+    for (Eigen::Index cntCoeff{}; cntCoeff < maxRoots; ++cntCoeff) {
+      double coeff{coeffs(cntCoeff)};
+      bool coeffAlmostZero{abs(coeff) <= absTol};
+
+      // root candidate at coefficient
+      if (coeffAlmostZero) {
+        double greville = m_basis->greville(cntCoeff);
+
+        if (isRoot(greville, dim, absTol))
+          roots(cntRoots++) = greville;
+      }
+
+      // root between coefficients
+      else if (cntCoeff < maxRoots - 1) {
+        double nextCoeff{coeffs(cntCoeff + 1)};
+        bool nextNotZero{abs(nextCoeff) > absTol};
+        bool containsRoot{coeff * nextCoeff <= 0};
+
+        if (nextNotZero && containsRoot)
+          rootIdcs(cntRoots++) = cntCoeff;
+      }
+    }
+
+    return {rootIdcs.head(cntRoots), roots.head(cntRoots)};
+  }
+
+  /**
+   * @brief Determines if a "value" is condsidered a root for the given absolte
+   * tolerance "absTol".
+   *
+   * @param value Test value to check for root.
+   * @param dim Output dimension to check against.
+   * @param absTol Absolute tolerance for considering the "value" a root.
+   * @return true The "value" is a root.
+   * @return false The "value" is not a root.
+   */
+  bool isRoot(double value, int dim, double absTol) const {
+    return abs((*this)({{value}})(0, dim)) <= absTol;
   }
 };
 }; // namespace BasisSplines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "basis-splines"
-version = "1.0.4"
+version = "1.0.5"
 readme = "docs/README.pypi.md"
 dependencies = ["numpy"]
 authors = [{ name = "Philip Dorpmüller", email = "philip.dorpmueller@web.de" }]

--- a/test/splineTest.cpp
+++ b/test/splineTest.cpp
@@ -323,8 +323,56 @@ TEST_F(SplineTest, GetSegment11O4) {
   valuesEst = splineClamped(pointsSubset);
   expectAllClose(valuesEst, valuesGtr, 1e-10);
 
-  EXPECT_DOUBLE_EQ(splineClamped.getCoefficients()(0), splineClamped(Eigen::ArrayXd{{breakpoints.first(1)}})(0,0));
-  EXPECT_DOUBLE_EQ(splineClamped.getCoefficients()(3), splineClamped(Eigen::ArrayXd{{breakpoints.first(2)}})(0,0));
+  EXPECT_DOUBLE_EQ(splineClamped.getCoefficients()(0),
+                   splineClamped(Eigen::ArrayXd{{breakpoints.first(1)}})(0, 0));
+  EXPECT_DOUBLE_EQ(splineClamped.getCoefficients()(3),
+                   splineClamped(Eigen::ArrayXd{{breakpoints.first(2)}})(0, 0));
+}
+
+/**
+ * @brief Test getting all zeros of a 2nd degree polynomial with a root at 0.0.
+ *
+ * The root is on the left domain end.
+ *
+ */
+TEST_F(SplineTest, ZerosLeftSplineO3) {
+  const std::vector<Eigen::ArrayXd> valuesEst{m_splineO3.getRoots()};
+  const Eigen::ArrayXd valuesGtr{{0.0}};
+
+  for (const Eigen::ArrayXd &valueEst : valuesEst)
+    expectAllClose(valueEst, valuesGtr, 1e-6);
+}
+
+/**
+ * @brief Test getting all zeros of a 2nd degree polynomial with a root at 1.0.
+ *
+ * The root is on the right domain end.
+ *
+ */
+TEST_F(SplineTest, ZerosRightSplineO3) {
+  const Spline splineO3 {m_splineO3.basis(), m_splineO3.getCoefficients().array() - 1.0};
+  const std::vector<Eigen::ArrayXd> valuesEst{splineO3.getRoots()};
+  const Eigen::ArrayXd valuesGtr{splineO3.basis()->knots().tail(1)};
+
+  for (const Eigen::ArrayXd &valueEst : valuesEst)
+    expectAllClose(valueEst, valuesGtr, 1e-6);
+}
+
+/**
+ * @brief Test getting all zeros of a 3rd order spline with random coefficients.
+ *
+ */
+TEST_F(SplineTest, ZerosSplineO3Rand) {
+  const Spline spline{m_basisO3, Eigen::MatrixXd::Random(m_basisO3->dim(), 3)};
+  const std::vector<Eigen::ArrayXd> zeroVects{spline.getRoots()};
+
+  int dim{};
+  for (const auto &zeros : zeroVects) {
+    Eigen::ArrayXd valuesEst{spline(zeros)(Eigen::all, dim)};
+    Eigen::ArrayXd valuesGtr{Eigen::ArrayXd::Zero(zeros.size())};
+    expectAllClose(valuesEst, valuesGtr, 1e-6);
+    ++dim;
+  }
 }
 
 }; // namespace Internal


### PR DESCRIPTION
Add methods to the [spline class](https://github.com/phdorp/basis-splines/blob/db4dae17ef463f63e6fe0f549eb4720b5e5fe983/include/basisSplines/spline.h) that enable root finding along each output dimension.